### PR TITLE
refactor: restructure keyboard layers for US/SJIS separation

### DIFF
--- a/config/roBa.keymap
+++ b/config/roBa.keymap
@@ -91,6 +91,11 @@
             bindings = <&apple_toggle>;
             key-positions = <0 9>;
         };
+
+        sjis_mode_toggle {
+            bindings = <&sjis_toggle>;
+            key-positions = <1 8>;
+        };
     };
 
     macros {
@@ -106,6 +111,13 @@
             #binding-cells = <0>;
             bindings = <&tog 7>;
             label = "APPLE_TOGGLE";
+        };
+
+        sjis_toggle: sjis_toggle {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings = <&tog 8>;
+            label = "SJIS_TOGGLE";
         };
     };
 
@@ -135,7 +147,7 @@
         default_layer {
             bindings = <
 &qq_esc_lang2     &kp W           &kp E         &kp R                    &kp T                                                            &kp Y        &kp U  &lt 4 I      &kp O    &kp P
-&mt LEFT_SHIFT A  &kp S           &kp D         &kp F                    &kp G        &esc_lang2                &kp K_VOLUME_UP           &kp H        &kp J  &kp K        &kp L    &mt RSHIFT JP_COLON
+&mt LEFT_SHIFT A  &kp S           &kp D         &kp F                    &kp G        &esc_lang2                &kp K_VOLUME_UP           &kp H        &kp J  &kp K        &kp L    &mt RSHIFT SEMICOLON
 &mt LSHIFT Z      &kp X           &kp C         &kp V                    &kp B        &lt_to_layer_0 6 TAB      &mt K_MUTE K_VOLUME_DOWN  &kp N        &kp M  &lt 5 COMMA  &kp DOT  &mt RSHIFT SLASH
 &kp LCTRL         &lt 1 K_MUTE  &kp LEFT_WIN  &mt LEFT_ALT LANGUAGE_2  &lt 2 LANGUAGE_2  &lt 3 BSPC                &kp SPACE                 &lt 2 LANG1                               &lt 4 ENTER
             >;
@@ -193,7 +205,7 @@
         layer_6 {
             bindings = <
 &trans  &trans        &trans        &trans        &trans                           &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-&trans  &trans        &trans        &trans        &trans  &trans      &trans       &trans        &trans        &trans        &trans        &apple_toggle
+&trans  &trans        &trans        &trans        &trans  &trans      &trans       &trans        &trans        &trans        &sjis_toggle  &apple_toggle
 &trans  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &trans  &trans      &bootloader  &trans        &trans        &trans        &trans        &bt BT_CLR
 &trans  &trans        &trans        &trans        &trans  &trans      &trans       &trans                                                  &bt BT_CLR_ALL
             >;
@@ -201,10 +213,21 @@
 
         APPLE {
             bindings = <
-&qq_esc_lang2     &kp W           &kp E         &kp R                    &kp T                                                            &kp Y        &kp U  &lt 4 I      &kp O    &kp P
-&mt LEFT_SHIFT A  &kp S           &kp D         &kp F                    &kp G        &esc_lang2                &kp K_VOLUME_UP           &kp H        &kp J  &kp K        &kp L    &mt RSHIFT JP_COLON
-&mt LSHIFT Z      &kp X           &kp C         &kp V                    &kp B        &lt_to_layer_0 6 TAB      &mt K_MUTE K_VOLUME_DOWN  &kp N        &kp M  &lt 5 COMMA  &kp DOT  &mt RSHIFT SLASH
-&kp LCTRL         &lt 1 K_MUTE    &kp APPLE_OPT &mt APPLE_CMD LANGUAGE_2 &lt 2 LANGUAGE_2   &lt 3 BSPC          &kp SPACE                 &lt 2 LANG1                               &lt 4 ENTER
+&trans  &trans  &trans  &trans  &trans                      &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &kp APPLE_OPT  &mt APPLE_CMD LANGUAGE_2  &trans  &trans      &trans  &trans                          &trans
+            >;
+
+            sensor-bindings = <&inc_dec_kp PG_UP PAGE_DOWN>;
+        };
+
+        SJIS {
+            bindings = <
+&trans  &trans  &trans  &trans  &trans                      &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &trans  &trans  &trans  &mt RSHIFT JP_COLON
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans  &trans  &trans  &trans  &trans
+&trans  &trans  &trans  &trans  &trans  &trans      &trans  &trans                          &trans
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PAGE_DOWN>;


### PR DESCRIPTION
- Simplify Apple layer to only define thumb keys (APPLE_OPT, APPLE_CMD)
- Change default layer from JIS to US layout (SEMICOLON instead of JP_COLON) 
- Add new SJIS layer (layer 8) for Japanese-specific key mappings
- Add SJIS toggle macro and W+I combo for easy switching
- Add SJIS toggle button to settings layer (layer 6)

This allows for:
- Clean separation between US and Japanese layouts
- Minimal Apple layer that only overrides modifier keys
- Flexible switching between input modes